### PR TITLE
chore(turbo): rename turbo lint cmd for staged

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
-  "**/*.{js,mjs,ts,tsx}": ["turbo run lint --", "prettier --check"],
+  "**/*.{js,mjs,ts,tsx}": ["turbo run lint:lint-staged --", "prettier --check"],
   "**/*.{css,md,mdx,json,yml}": ["prettier --check"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,9 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "lint:lint-staged": {
+      "dependsOn": ["^lint"]
+    },
     "check-types": {
       "dependsOn": ["^check-types"]
     },


### PR DESCRIPTION
* rename to  lint:lint-staged to move it away from the scripts in apps and packages